### PR TITLE
Configuring tags from options in scope when constructing the transport

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -60,6 +60,14 @@ class Sentry extends TransportStream {
       this.sentryClient.init({
         dsn: options.dsn,
       });
+
+      this.sentryClient.configureScope((scope: any) => {
+        if (!_.isEmpty(this.tags)) {
+          Object.keys(this.tags).forEach((key) => {
+            scope.setTag(key, this.tags[key]);
+          });
+        }
+      });
     }
   }
 


### PR DESCRIPTION
Allows tags to be sent with fatal-level messages from captured unhandled errors.  Reference #5.