### PR TITLE
Support more sentry config

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import sentry from '@sentry/node';
 import { isError } from '@sentry/utils/is';
 import _ from 'lodash';
-import TransportStream from 'winston-transport';
+import TransportStream = require('winston-transport');
 
 import { Context } from './types';
 
@@ -10,7 +10,7 @@ const errorHandler = (err: any) => {
   console.error(err);
 };
 
-export class Sentry extends TransportStream {
+export default class Sentry extends TransportStream {
   protected name: string;
   protected tags: {[s: string]: any};
   protected sentryClient: typeof sentry;
@@ -117,5 +117,3 @@ export class Sentry extends TransportStream {
     });
   }
 }
-
-module.exports = Sentry;


### PR DESCRIPTION
I noticed that not all of the configuration that is available for Sentry was handed over. Especially I was missing the `beforeSend` event hook and support for `modules`. With this PR the following should be possible:

```typescript
const s = new Sentry({
    level: 'warn',
    config: {
        tags: {'foo': 'bar'},
        release: 'your-release',
        environment: 'your-environment',
        serverName: 'your-server-name',
        attachStacktrace: true,
        captureUnhandledRejections: true,
        beforeSend: (event: SentryEvent, hint?: SentryEventHint) => {
            event.modules = {'list-of': 'your-modules'};
            return event;
        },
    },
});

logger.add(s);
```

I had *massive* trouble with TypeScript and imports. Turns out that the last line in `index.ts` was the reason behind it:

```typescript
module.exports = Sentry;
```

I've changed that to `default export Sentry` and had to change the way `winston.TransportStream` is imported. See official TypeScript documentation for details:

> When exporting a module using `export =`, TypeScript-specific `import module = require("module")` must be used to import the module.
>
> *Source: https://www.typescriptlang.org/docs/handbook/modules.html#export--and-import--require*