### PR TITLE
Fix reported level with `captureMessage`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -112,7 +112,7 @@ export default class Sentry extends TransportStream {
         this.sentryClient.captureException(isError(info) ? info : new Error(message));
         return callback(null, true);
       }
-      this.sentryClient.captureMessage(message);
+      this.sentryClient.captureMessage(message, context.level);
       return callback(null, true);
     });
   }


### PR DESCRIPTION
Hi. `captureMessage` has 2nd argument that is the level (otherwise everything reported will be shown as `info` in Sentry).