### PR TITLE
Fixing DSN option in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ import winston from 'winston';
 import Sentry from 'winston-sentry-log';
 
 const options = {
-  dsn: "https://******@sentry.io/12345",
+  config: {
+    dsn: "https://******@sentry.io/12345"
+  },
   level: "info"
 };
 


### PR DESCRIPTION
Resolves issue #15

This package works fine, however. It took me a while to figure out why it wasn't working.
After digging in the code I saw that it was expecting the `dsn` in the `config`.
Also saw that there already was an issue for this. From a year ago.

I hope this helps.