### PR TITLE
Fix stack issue when using winston.format.combine

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -109,7 +109,16 @@ export default class Sentry extends TransportStream {
         scope.setUser(user);
       }
       if (context.level === 'error' || context.level === 'fatal') {
-        this.sentryClient.captureException(isError(info) ? info : new Error(message));
+        let err = null;
+        if (isError(info) === true) {
+          err = info;
+        } else {
+          err = new Error(message);
+          if (info.stack) {
+            err.stack = info.stack;
+          }
+        }
+        this.sentryClient.captureException(err);
         return callback(null, true);
       }
       this.sentryClient.captureMessage(message, context.level);


### PR DESCRIPTION
Resolves issue #1

Problem is then when you use format in your winston logger, winston will create an object (`info`).
Even if you do something like `console.error(new Error('error'));` it still generates an object.
The properties depends on which formats you use.
I use label, timestamp, colorize. And `info` object was something like:
```
info: {
  level: '\u001b[31merror\u001b[39m',
  label: '\u001b[36mMain.js\u001b[39m',
  timestamp: '08-04 11:12:51',
  message: '   Error: Endpoints are loaded',
  stack: 'Error: Error: Endpoints are loaded\n' +
    '    at DerivedLogger.Logger.loggerInstance.error (/path/to/my/logger.js:68:19)\n' +
    '    at /path/to/my/main.js:21:7',
  [Symbol(level)]: 'error',
  [Symbol(message)]: '08-04 11:12:51 [\u001b[36mMain.js\u001b[39m] \u001b[31merror\u001b[39m:    Error: Endpoints are loaded '
}
```

So the `isError` check now fails. When I remove the whole winston format part, it works just fine.
I think this is the same problem as described in issue #1 
The solution that works for me in this case, is using the error format from winston:
```
winston.format.errors({ stack: true })
```
Which will add a stack to the `info` object.
The `isError` check fails (returns false) so it'll create a new Error.
However, the stack is known in `info.stack`, so we'll update the stack of the new Error to the stack provided by `info.stack` so your Sentry stack doesn't show just the internal files of Winston and this module but use the one from where you actually fire your `log.error`