### PR TITLE
Use meta.tags as sentry tags

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -90,7 +90,7 @@ export default class Sentry extends TransportStream {
 
     const context: Context = {};
     context.level = this.levelsMap[level];
-    context.extra = _.omit(meta, ['user']);
+    context.extra = _.omit(meta, ['user', 'tags']);
     context.fingerprint = [fingerprint, process.env.NODE_ENV];
     this.sentryClient.configureScope((scope: sentry.Scope) => {
       const user = _.get(meta, 'user');
@@ -99,14 +99,23 @@ export default class Sentry extends TransportStream {
           scope.setExtra(key, context.extra[key]);
         });
       }
+
       if (!_.isEmpty(this.tags)) {
         Object.keys(this.tags).forEach((key) => {
           scope.setTag(key, this.tags[key]);
         });
       }
+
+      if (!_.isEmpty(meta.tags) && _.isObject(meta.tags)) {
+        Object.keys(meta.tags).forEach((key) => {
+          scope.setTag(key, meta.tags[key]);
+        });
+      }
+
       if (!!user) {
         scope.setUser(user);
       }
+
       if (context.level === 'error' || context.level === 'fatal') {
         let err = null;
         if (_.isError(info) === true) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -92,17 +92,11 @@ export default class Sentry extends TransportStream {
     context.level = this.levelsMap[level];
     context.extra = _.omit(meta, ['user', 'tags']);
     context.fingerprint = [fingerprint, process.env.NODE_ENV];
-    this.sentryClient.configureScope((scope: sentry.Scope) => {
+    this.sentryClient.withScope((scope: sentry.Scope) => {
       const user = _.get(meta, 'user');
       if (_.has(context, 'extra')) {
         Object.keys(context.extra).forEach((key) => {
           scope.setExtra(key, context.extra[key]);
-        });
-      }
-
-      if (!_.isEmpty(this.tags)) {
-        Object.keys(this.tags).forEach((key) => {
-          scope.setTag(key, this.tags[key]);
         });
       }
 


### PR DESCRIPTION
Hi There,

Is there any concerns to not use `meta.tags` as sentry tags or it is just missed?

It looks really handy for me.

Also I noticed that you are using configureScope on event level, I suppose it has to be withScope, so the scope values will be clean right after message sent, see https://docs.sentry.io/enriching-error-data/scopes/?platform=javascript#local-scopes 

Thanks for your time.